### PR TITLE
Fixed propagating of concat plugin options

### DIFF
--- a/tasks/netteBasePath.js
+++ b/tasks/netteBasePath.js
@@ -43,6 +43,9 @@ module.exports = function(grunt) {
     var concat = grunt.config('concat') || {},
       uglify = grunt.config('uglify') || {},
       cssmin = grunt.config('cssmin') || { compress: { files: {} }};
+    if(concat.options) {
+        concatFixed.options = concat.options;
+    }
 
     var clearBasePath = function(path){
       return path.replace('{$basePath}', basePath);


### PR DESCRIPTION
This pull allows propagating of custom config of grunt-contrib-concat (options property).

Maybe this is an issue for other used plugins as well...
